### PR TITLE
add clickable links to news letter

### DIFF
--- a/content/blog/2024-3-news-letter.md
+++ b/content/blog/2024-3-news-letter.md
@@ -12,8 +12,8 @@ In the March 2024 newsletter we would like to focus on some support and training
 
 **HPC office hours**
 
-Every Wednesday, 10:30-12:00, the HPC group staff is available for users to chat either in person in Modulbygget, Room A209 and A210 [https://link.mazemap.com/yfStfXRc](https://link.mazemap.com/yfStfXRc)
-or on Teams. For more info, please see [https://hpc.uit.no/contact/](https://hpc.uit.no/contact/ ) and keep an eye on [https://uit.no/tavla](https://uit.no/tavla) where we post about the events.
+Every Wednesday, 10:30-12:00, the HPC group staff is available for users to chat either in person in Modulbygget, Room A209 and A210 <https://link.mazemap.com/yfStfXRc>
+or on Teams. For more info, please see <https://hpc.uit.no/contact/> and keep an eye on <https://uit.no/tavla> where we post about the events.
 
 On March 27 (Wednesday before Easter) and April 10 (HPC onboarding course) we will pause the HPC office hours.
 
@@ -23,19 +23,19 @@ On March 27 (Wednesday before Easter) and April 10 (HPC onboarding course) we wi
 NRIS is offering a best practices course for users of national infrastructure services.
 The workshop is organised as a series of monthly events. The series starts on 8th February and ends on 23 May.
 During these monthly training events, each topic will focus on different aspects related to the everyday usage of HPC/storage facilities:
-[https://documentation.sigma2.no/training/events/2024-spring-best-practices-series.html](https://documentation.sigma2.no/training/events/2024-spring-best-practices-series.html)
+<https://documentation.sigma2.no/training/events/2024-spring-best-practices-series.html>
 
 The course is open to all and free of charge, but registration is mandatory.
 The next event is already this Thursday and is dedicated to installation of software on NRIS machines as a user.
-Register here: [https://skjemaker.app.uib.no/view.php?id=16408810](https://skjemaker.app.uib.no/view.php?id=16408810)
+Register here: <https://skjemaker.app.uib.no/view.php?id=16408810>
 
 
 **HPC onboarding course in April**
 
 The popular NRIS beginners course – HPC onboarding – is being arranged just after Easter, April 9-11, 2024:
-[https://documentation.sigma2.no/training/events/2024-04-hpc-on-boarding.html](https://documentation.sigma2.no/training/events/2024-04-hpc-on-boarding.html)
+<https://documentation.sigma2.no/training/events/2024-04-hpc-on-boarding.html>
 
-This course is now open for registration: [https://skjemaker.app.uib.no/view.php?id=16342012](https://skjemaker.app.uib.no/view.php?id=16342012).
+This course is now open for registration: <https://skjemaker.app.uib.no/view.php?id=16342012>.
 
 
 Best regards,

--- a/content/blog/2024-3-news-letter.md
+++ b/content/blog/2024-3-news-letter.md
@@ -12,8 +12,8 @@ In the March 2024 newsletter we would like to focus on some support and training
 
 **HPC office hours**
 
-Every Wednesday, 10:30-12:00, the HPC group staff is available for users to chat either in person in Modulbygget, Room A209 and A210 (https://link.mazemap.com/yfStfXRc)
-or on Teams. For more info, please see https://hpc.uit.no/contact/ and keep an eye on https://uit.no/tavla where we post about the events.
+Every Wednesday, 10:30-12:00, the HPC group staff is available for users to chat either in person in Modulbygget, Room A209 and A210 [https://link.mazemap.com/yfStfXRc](https://link.mazemap.com/yfStfXRc)
+or on Teams. For more info, please see [https://hpc.uit.no/contact/](https://hpc.uit.no/contact/ ) and keep an eye on [https://uit.no/tavla](https://uit.no/tavla) where we post about the events.
 
 On March 27 (Wednesday before Easter) and April 10 (HPC onboarding course) we will pause the HPC office hours.
 
@@ -23,19 +23,19 @@ On March 27 (Wednesday before Easter) and April 10 (HPC onboarding course) we wi
 NRIS is offering a best practices course for users of national infrastructure services.
 The workshop is organised as a series of monthly events. The series starts on 8th February and ends on 23 May.
 During these monthly training events, each topic will focus on different aspects related to the everyday usage of HPC/storage facilities:
-https://documentation.sigma2.no/training/events/2024-spring-best-practices-series.html
+[https://documentation.sigma2.no/training/events/2024-spring-best-practices-series.html](https://documentation.sigma2.no/training/events/2024-spring-best-practices-series.html)
 
 The course is open to all and free of charge, but registration is mandatory.
 The next event is already this Thursday and is dedicated to installation of software on NRIS machines as a user.
-Register here: https://skjemaker.app.uib.no/view.php?id=16408810
+Register here: [https://skjemaker.app.uib.no/view.php?id=16408810](https://skjemaker.app.uib.no/view.php?id=16408810)
 
 
 **HPC onboarding course in April**
 
 The popular NRIS beginners course – HPC onboarding – is being arranged just after Easter, April 9-11, 2024:
-https://documentation.sigma2.no/training/events/2024-04-hpc-on-boarding.html
+[https://documentation.sigma2.no/training/events/2024-04-hpc-on-boarding.html](https://documentation.sigma2.no/training/events/2024-04-hpc-on-boarding.html)
 
-This course is now open for registration: https://skjemaker.app.uib.no/view.php?id=16342012.
+This course is now open for registration: [https://skjemaker.app.uib.no/view.php?id=16342012](https://skjemaker.app.uib.no/view.php?id=16342012).
 
 
 Best regards,


### PR DESCRIPTION
Forgot to make links "clickable" in markdown file. Currently, the whole url is displayed but we could also hide them like
[link](https://hpc.uit.no/), instead of [https://hpc.uit.no/](https://hpc.uit.no/). What do you think?