### PR TITLE
Make blinkin lights responsive to pagewidth.

### DIFF
--- a/sass/style.scss
+++ b/sass/style.scss
@@ -154,3 +154,23 @@ $heading-color: #404040;
   object-fit: contain;
   margin-right: 2vw;
 }
+
+.lights-grid {
+  display: flex;
+  /* Change this from grid to flex */
+  overflow: hidden;
+  /* Add this line to hide the lights that overflow the container */
+  height: 15px;
+  /* Adjust the height of the lights as needed */
+  width: auto;
+}
+
+.light {
+  display: inline-block;
+  width: 10px;
+  /* Adjust the size of the lights as needed */
+  height: 10px;
+  /* Adjust the size of the lights as needed */
+  margin-right: 3px;
+  /* Set the size of the gap between the lights */
+}

--- a/templates/blinkenlights.html
+++ b/templates/blinkenlights.html
@@ -1,7 +1,9 @@
 {% for i in range(end=3) %}
-  <div>
-    {% for j in range(end=88) %}
-      <div style="display: inline;" class="blink_{{ get_random(start=0, end=5) }} color_{{ get_random(start=0, end=2) }}">&#9632;</div>
+  <div class="lights-grid">
+    {% for j in range(end=100) %}
+    <div style="display: inline;"
+      class="light blink_{{ get_random(start=0, end=5) }} color_{{ get_random(start=0, end=2) }}">&#9632;
+    </div>
     {% endfor %}
   </div>
-{% endfor %}
+  {% endfor %}


### PR DESCRIPTION
Now the blinkenlights do not bunch up and cover all the page in smaller screens