### PR TITLE
add calendar to hpc website

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -77,8 +77,14 @@ and managed by [Sigma2](https://www.sigma2.no/).
 
 {{ div(attributes='class="uk-card uk-card-secondary uk-card-body uk-margin-large-top"') }}
 ## Office hours: Every Wednesday 10:30 - 12:00
+{{ div(attributes='class="events-container"')  }}
+{{ div(attributes='class="calendar"')  }}
+  <iframe src="https://calendar.google.com/calendar/embed?height=375&wkst=2&ctz=Europe%2FBerlin&bgcolor=%23ffffff&showTz=0&showPrint=0&title&showTitle=0&src=Y19iMzFmOTAxM2NiMTJiODRmNzJjNmU0MGVhZWE2YWQ4ZWVhZDY2YTQ0MzUzMGNjODgzZDJiMzc3NmM5MTk5ZjMxQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20&color=%233F51B5" style="border-width:0" width="500" height="375" frameborder="0" scrolling="no"></iframe>
+{{ enddiv()}}
 
 Need help with anything high-performance computing or NRIS related? Or do need more computing power than your laptop can provide?  Then visit us during our office hours.
 Every Wednesday 10:30 - 12:00 in [room A209 in
 Modulbygget](https://use.mazemap.com/#v=1&zlevel=2&center=18.972617,69.683509&zoom=16.3&campusid=5&sharepoitype=poi&sharepoi=174370).
+
+{{ enddiv()}}
 {{ enddiv() }}

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -174,3 +174,28 @@ $heading-color: #404040;
   margin-right: 3px;
   /* Set the size of the gap between the lights */
 }
+.events-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 20px;
+  justify-content: normal;
+  margin: auto;
+}
+
+.calendar {
+  position: relative;
+  padding-bottom: 75%;
+  /* This ratio determines the aspect ratio of the calendar, which is height / width. Adjust as needed. */
+  height: 0;
+  overflow: hidden;
+}
+
+.calendar iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100% !important;
+  /* Overriding inline styles */
+  height: 100% !important;
+  /* Overriding inline styles */
+}


### PR DESCRIPTION
I am trying to integrate a calendar for the events and hpc-office hours issues. 
I think I can set this calendar up so that we can push. events into it and they will automatically display on the website.

TODOs:
- [ ] Allow HPC staff to edit calendar
- [ ] Allow users to follow the calendar 
- [ ] better descriptive text next to the calendar
- [ ] better formatting of the calendar
    - use google calendar api or rss feed and remake a calendar of our own
    - dont use google calendars and use an open source solution for prettier calendars